### PR TITLE
Removed date generation from offset class

### DIFF
--- a/lib/offset.rb
+++ b/lib/offset.rb
@@ -1,21 +1,21 @@
 require 'date'
 
 class Offset
-  def todays_date
-    Time.now.strftime("%d%m%y")
+  attr_reader :date
+
+  def initialize(date)
+    @date = date
   end
 
   def generate_offset
-    (todays_date.to_i ** 2).to_s.slice(-4..-1)
+  (date.to_i ** 2).to_s.slice(-4..-1)
   end
 
   def final_offset
-    date = generate_offset
-    final_offset = Hash.new(0)
-    final_offset = { A: date[0].to_i,
-                     B: date[1].to_i,
-                     C: date[2].to_i,
-                     D: date[3].to_i
-                   }
+    { A: generate_offset[0].to_i,
+      B: generate_offset[1].to_i,
+      C: generate_offset[2].to_i,
+      D: generate_offset[3].to_i
+    }
   end
 end

--- a/test/offset_test.rb
+++ b/test/offset_test.rb
@@ -4,19 +4,21 @@ require './lib/offset'
 
 class OffsetTest < Minitest::Test
 
-  def test_it_knows_todays_date
-    offset = Offset.new
-    assert_equal Time.now.strftime("%d%m%y"), offset.todays_date
+  def test_it_exists
+    offset = Offset.new("040895")
+    assert_instance_of Offset, offset
   end
 
   def test_it_finds_last_digits_of_squared_date
-    offset = Offset.new
-    assert_equal "4400", offset.generate_offset
+    offset = Offset.new("040895")
+    assert_equal "1025", offset.generate_offset
   end
 
   def test_it_splits_offset_into_hash
-    offset = Offset.new
+    offset = Offset.new("040895")
     offset.generate_offset
     assert_equal 4, offset.final_offset.length
+    expected = ({A: 1, B: 0, C: 2, D: 5})
+    assert_equal expected, offset.final_offset
   end
 end


### PR DESCRIPTION
This, like key generation, should not be called every time. These should only be generated as conditionals if user does not input them.